### PR TITLE
[Test] Order Module Unit Tests

### DIFF
--- a/ALitlleLeaf.Test/Controllers/AdminOrderControllerTests.cs
+++ b/ALitlleLeaf.Test/Controllers/AdminOrderControllerTests.cs
@@ -1,0 +1,80 @@
+﻿using ALittleLeaf.Areas.Admin.Controllers;
+using ALittleLeaf.Models;
+using ALittleLeaf.Repository;
+using ALittleLeaf.Tests.Helpers;
+using ALittleLeaf.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ALittleLeaf.Tests.Controllers
+{
+    public class AdminOrderControllerTests : IDisposable
+    {
+        private readonly AlittleLeafDecorContext _context;
+        private readonly OrdersController _controller;
+
+        public AdminOrderControllerTests()
+        {
+            _context = DbContextFactory.Create();
+            _controller = new OrdersController(_context);
+        }
+
+        public void Dispose()
+        {
+            DbContextFactory.Destroy(_context);
+        }
+
+        [Fact]
+        public void UpdateStatus_Post_UpdatesDatabaseAndRedirects()
+        {
+            // Arrange
+            // Tạo Bill mẫu trong DB
+            var bill = new Bill
+            {
+                IdUser = 1,
+                BillId = 100,
+                IsConfirmed = false,
+                PaymentStatus = "Pending",
+                ShippingStatus = "Not Shipped",
+                DateCreated = DateOnly.FromDateTime(DateTime.Now),
+
+                // --- THÊM DÒNG NÀY ---
+                PaymentMethod = "COD",  // <--- Bổ sung trường bắt buộc
+                IdAdrs = 1 // (Tùy chọn) Nên thêm ID địa chỉ giả để dữ liệu chuẩn hơn
+            };
+            _context.Bills.Add(bill);
+            _context.SaveChanges();
+
+            // Act
+            // Giả lập Admin confirm đơn hàng
+            var result = _controller.UpdateStatus(100, true, "Paid", "Shipped");
+
+            // Assert
+            var redirectResult = Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Details", redirectResult.ActionName);
+
+            // Check DB
+            var updatedBill = _context.Bills.Find(100);
+            Assert.True(updatedBill.IsConfirmed);
+            Assert.Equal("Paid", updatedBill.PaymentStatus);
+            Assert.Equal("Shipped", updatedBill.ShippingStatus);
+        }
+
+        [Fact]
+        public async Task Statistics_ReturnsViewModel()
+        {
+            // Act
+            var result = await _controller.Statistics(null, null);
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsType<OrderStatisticsViewModel>(viewResult.Model);
+            Assert.NotNull(model.RecentOrders);
+            // Có thể kiểm tra thêm model.TotalOrders nếu đã seed data trong DbContextFactory
+        }
+    }
+}

--- a/ALitlleLeaf.Test/Controllers/CustomerOrderControllerTests.cs
+++ b/ALitlleLeaf.Test/Controllers/CustomerOrderControllerTests.cs
@@ -1,0 +1,123 @@
+﻿using ALittleLeaf.Controllers;
+using ALittleLeaf.Models;
+using ALittleLeaf.Services; // IAuthService
+using ALittleLeaf.Services.Auth;
+using ALittleLeaf.Services.Order;
+using ALittleLeaf.ViewModels;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ALittleLeaf.Tests.Controllers
+{
+    public class CustomerOrderControllerTests
+    {
+        private readonly Mock<IOrderService> _mockOrderService;
+        private readonly Mock<IAuthService> _mockAuthService;
+        private readonly AccountController _controller;
+
+        public CustomerOrderControllerTests()
+        {
+            _mockOrderService = new Mock<IOrderService>();
+            _mockAuthService = new Mock<IAuthService>();
+
+            // Mock User Login (UserId = 1)
+            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
+            {
+                new Claim("Id", "1"),
+            }, "mock"));
+
+            _controller = new AccountController(_mockAuthService.Object, _mockOrderService.Object)
+            {
+                ControllerContext = new ControllerContext
+                {
+                    HttpContext = new DefaultHttpContext { User = user }
+                }
+            };
+        }
+
+        // ORDL-01: Hiển thị danh sách đơn hàng (Có đơn)
+        [Fact]
+        public async Task Index_HasOrders_ReturnsViewWithList()
+        {
+            // Arrange
+            var orders = new List<Bill>
+            {
+                new Bill { BillId = 1, TotalAmount = 100000 },
+                new Bill { BillId = 2, TotalAmount = 200000 }
+            };
+            _mockOrderService.Setup(s => s.GetOrderHistoryAsync(1)).ReturnsAsync(orders);
+
+            // Act
+            var result = await _controller.Index();
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<List<Bill>>(viewResult.Model);
+            Assert.Equal(2, model.Count);
+        }
+
+        // ORDL-02: Hiển thị danh sách đơn hàng (Trống)
+        [Fact]
+        public async Task Index_NoOrders_ReturnsEmptyList()
+        {
+            // Arrange
+            _mockOrderService.Setup(s => s.GetOrderHistoryAsync(1)).ReturnsAsync(new List<Bill>());
+
+            // Act
+            var result = await _controller.Index();
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<List<Bill>>(viewResult.Model);
+            Assert.Empty(model);
+        }
+
+        // ORD-01: Xem chi tiết đơn hàng (Thành công)
+        [Fact]
+        public async Task OrderDetails_ValidId_ReturnsViewWithDetails()
+        {
+            // Arrange
+            int billId = 10;
+            var bill = new Bill { BillId = 10, TotalAmount = 50000 };
+            var details = new List<OrderDetailViewModel>
+            {
+                new OrderDetailViewModel { ProductName = "Product A", Quantity = 1 }
+            };
+
+            _mockOrderService.Setup(s => s.GetBillByIdAsync(billId, 1)).ReturnsAsync(bill);
+            _mockOrderService.Setup(s => s.GetBillDetailsAsync(billId)).ReturnsAsync(details);
+
+            // Act
+            var result = await _controller.OrderDetails(billId);
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<List<OrderDetailViewModel>>(viewResult.Model); // View nhận details
+            Assert.Single(model);
+
+            // Kiểm tra ViewBag chứa Bill info
+            Assert.NotNull(_controller.ViewBag.Bill);
+            var billInViewBag = (Bill)_controller.ViewBag.Bill;
+            Assert.Equal(10, billInViewBag.BillId);
+        }
+
+        // ORD Error: Xem đơn hàng không tồn tại (hoặc của người khác)
+        [Fact]
+        public async Task OrderDetails_InvalidId_ReturnsNotFound()
+        {
+            // Arrange
+            _mockOrderService.Setup(s => s.GetBillByIdAsync(999, 1)).ReturnsAsync((Bill)null);
+
+            // Act
+            var result = await _controller.OrderDetails(999);
+
+            // Assert
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+}

--- a/ALitlleLeaf.Test/Services/OrderServiceTests.cs
+++ b/ALitlleLeaf.Test/Services/OrderServiceTests.cs
@@ -1,0 +1,188 @@
+﻿using ALittleLeaf.Models;
+using ALittleLeaf.Repository;
+using ALittleLeaf.Services.Order;
+using ALittleLeaf.Tests.Helpers;
+using ALittleLeaf.ViewModels;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims; // Cần để Mock User ID
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ALittleLeaf.Tests.Services
+{
+    public class OrderServiceTests : IDisposable
+    {
+        private readonly AlittleLeafDecorContext _context;
+        private readonly Mock<IHttpContextAccessor> _mockHttpContextAccessor;
+        private readonly Mock<ISession> _mockSession;
+        private readonly OrderService _service;
+        private Dictionary<string, byte[]> _sessionStore;
+
+        public OrderServiceTests()
+        {
+            _context = DbContextFactory.Create();
+            _sessionStore = new Dictionary<string, byte[]>();
+            _mockSession = new Mock<ISession>();
+
+            // 1. Setup Mock Session
+            _mockSession.Setup(s => s.Set(It.IsAny<string>(), It.IsAny<byte[]>()))
+                .Callback<string, byte[]>((key, value) => _sessionStore[key] = value);
+            _mockSession.Setup(s => s.TryGetValue(It.IsAny<string>(), out It.Ref<byte[]>.IsAny))
+                .Returns((string key, out byte[] value) => _sessionStore.TryGetValue(key, out value));
+            _mockSession.Setup(s => s.Remove(It.IsAny<string>()))
+                .Callback<string>(key => _sessionStore.Remove(key));
+
+            // 2. Setup Mock User (Để hàm GetUserId() hoạt động)
+            var claims = new List<Claim>
+            {
+                new Claim("Id", "1"), // Giả sử User ID = 1
+                new Claim(ClaimTypes.NameIdentifier, "1")
+            };
+            var identity = new ClaimsIdentity(claims, "TestAuthType");
+            var claimsPrincipal = new ClaimsPrincipal(identity);
+
+            // 3. Setup HttpContext
+            var mockContext = new Mock<HttpContext>();
+            mockContext.Setup(c => c.Session).Returns(_mockSession.Object);
+            mockContext.Setup(c => c.User).Returns(claimsPrincipal); // Gán User giả vào Context
+
+            _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+            _mockHttpContextAccessor.Setup(a => a.HttpContext).Returns(mockContext.Object);
+
+            _service = new OrderService(_context, _mockHttpContextAccessor.Object);
+        }
+
+        public void Dispose()
+        {
+            DbContextFactory.Destroy(_context);
+        }
+
+        // Helper: Ghi dữ liệu vào Session giả
+        private void SeedSessionData()
+        {
+            // Cart Data
+            var cart = new List<CartItemViewModel>
+            {
+                new CartItemViewModel { ProductId = 1, Quantity = 2, ProductPrice = 50000 }
+            };
+            _sessionStore["Cart"] = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(cart));
+
+            // Billing Data
+            _sessionStore["BillingAdrsId"] = Encoding.UTF8.GetBytes("new"); // Case tạo địa chỉ mới
+            _sessionStore["BillingFullName"] = Encoding.UTF8.GetBytes("Test User");
+            _sessionStore["BillingAddress"] = Encoding.UTF8.GetBytes("123 Street");
+            _sessionStore["BillingPhone"] = Encoding.UTF8.GetBytes("0909000111");
+            _sessionStore["BillNote"] = Encoding.UTF8.GetBytes("Test Note");
+        }
+
+        [Fact]
+        public async Task CreateOrderFromSessionAsync_ValidSession_CreatesBillAndDetails()
+        {
+            // Arrange
+            SeedSessionData();
+
+            // Act
+            var bill = await _service.CreateOrderFromSessionAsync("COD", "Pending");
+
+            // Assert
+            Assert.NotNull(bill);
+            Assert.Equal(100000, bill.TotalAmount); // 50k * 2
+            Assert.Equal("COD", bill.PaymentMethod);
+
+            // Kiểm tra DB
+            var savedBill = _context.Bills.FirstOrDefault(b => b.BillId == bill.BillId);
+            Assert.NotNull(savedBill);
+
+            var savedDetails = _context.BillDetails.Where(bd => bd.IdBill == bill.BillId).ToList();
+            Assert.Single(savedDetails);
+            Assert.Equal(1, savedDetails[0].IdProduct);
+
+            // Kiểm tra Address được tạo mới (vì BillingAdrsId = "new")
+            var savedAddress = _context.AddressLists.FirstOrDefault(a => a.AdrsAddress == "123 Street");
+            Assert.NotNull(savedAddress);
+        }
+
+        [Fact]
+        public async Task FulfillOrderAsync_ValidBill_DeductsStockAndClearsSession()
+        {
+            // Arrange
+            // 1. Tạo Bill & Detail trong DB
+            var bill = new Bill
+            {
+                IdUser = 1,
+                TotalAmount = 100000,
+                DateCreated = DateOnly.FromDateTime(DateTime.Now),
+
+                // --- THÊM CÁC DÒNG NÀY ---
+                PaymentMethod = "COD",
+                PaymentStatus = "Pending",
+                ShippingStatus = "Unfulfilled",
+                IdAdrs = 1
+            };
+            _context.Bills.Add(bill);
+            await _context.SaveChangesAsync(); 
+
+            _context.BillDetails.Add(new BillDetail
+            {
+                IdBill = bill.BillId,
+                IdProduct = 1, // Ấm Tráng Men (Tồn kho 100 - từ DbMock)
+                Quantity = 10
+            });
+            await _context.SaveChangesAsync();
+
+            // 2. Setup Session có dữ liệu (để check xem có bị xóa không)
+            SeedSessionData();
+
+            // Act
+            await _service.FulfillOrderAsync(bill.BillId);
+
+            // Assert
+            // 1. Kiểm tra tồn kho
+            var product = await _context.Products.FindAsync(1);
+            Assert.Equal(90, product.QuantityInStock); // 100 - 10 = 90
+
+            // 2. Kiểm tra Session bị xóa
+            Assert.False(_sessionStore.ContainsKey("Cart"));
+            Assert.False(_sessionStore.ContainsKey("BillingFullName"));
+        }
+
+        [Fact]
+        public async Task FulfillOrderAsync_NotEnoughStock_ThrowsException()
+        {
+            // Arrange
+            // SP ID 2 (Bếp Từ) có tồn kho = 10 (theo DbMock)
+            var bill = new Bill
+            {
+                IdUser = 1,
+                TotalAmount = 5000000,
+                DateCreated = DateOnly.FromDateTime(DateTime.Now),
+
+                // --- THÊM CÁC DÒNG NÀY ---
+                PaymentMethod = "Online",
+                PaymentStatus = "Paid",
+                ShippingStatus = "Unfulfilled",
+                IdAdrs = 1
+            };
+            _context.Bills.Add(bill);
+            await _context.SaveChangesAsync();
+
+            _context.BillDetails.Add(new BillDetail
+            {
+                IdBill = bill.BillId,
+                IdProduct = 2,
+                Quantity = 20 // Mua 20 > 10
+            });
+            await _context.SaveChangesAsync();
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<Exception>(() => _service.FulfillOrderAsync(bill.BillId));
+            Assert.Contains("không đủ hàng", ex.Message);
+        }
+    }
+}


### PR DESCRIPTION
Hoàn thành viết Unit Test cho module Đơn hàng (Order).

Các thay đổi:
- Thêm Unit Test cho `OrderService`:
    + Logic tạo đơn từ Session.
    + Logic trừ tồn kho (Stock Deduction) và Transaction.
- Thêm Unit Test cho `AccountController` (Customer): Xem lịch sử và chi tiết đơn hàng.
- Thêm Unit Test cho `Admin/OrdersController`: Cập nhật trạng thái và Thống kê doanh thu.
- Cập nhật `DbContextFactory` và `DbMock` hỗ trợ dữ liệu hóa đơn.

Closes #25 